### PR TITLE
remove pngquant which migh be very long for few/no results

### DIFF
--- a/demo/thumbor.conf
+++ b/demo/thumbor.conf
@@ -199,7 +199,7 @@ ALLOW_UNSAFE_URL = True
 #]
 
 OPTIMIZERS = [
-    'thumbor_plugins.optimizers.pngquant'
+    #'thumbor_plugins.optimizers.pngquant'
     #'thumbor_plugins.optimizers.pngcrush',
     #'thumbor_plugins.optimizers.auto'
     #'thumbor_plugins.optimizers.optipng'

--- a/source/image-handler/thumbor.conf
+++ b/source/image-handler/thumbor.conf
@@ -199,7 +199,7 @@ ALLOW_UNSAFE_URL = True
 #]
 
 OPTIMIZERS = [
-    'thumbor_plugins.optimizers.pngquant'
+    #'thumbor_plugins.optimizers.pngquant'
     #'thumbor_plugins.optimizers.pngcrush',
     #'thumbor_plugins.optimizers.auto'
     #'thumbor_plugins.optimizers.optipng'


### PR DESCRIPTION
pngquant use a lot of resources that make to png generation fail.

I made some tests with pngquant optimization:
before 945,37ko, after 968,87ko 
before 423,42ko after 147,36ko
before 551,40ko after 544,08ko
before 430,69ko after 483,72ko 

